### PR TITLE
docs: improve cp command in step 4 of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 1. `git clone https://github.com/catppuccin/kde`
 2. Choose a flavour.
 3. `cd kde/<your chosen flavor>.`
-4. `cp  ~/.local/share/color-schemes`.
+4. `cp Catppuccin<your chosen flavor>.colors ~/.local/share/color-schemes/Catppuccin<your chosen flavor>.colors`.
 5. `kpackagetool5 -i Catppuccin-<your chosen flavor>.tar.gz`.   
 You need an working internet connection for this to work. Make sure system settings is not running.
 6. `lookandfeel -a Catppuccin-<flavor>` or alternatively open system settings and choose the global theme


### PR DESCRIPTION
Added a small improvement in Step 4 of the README, specifying exactly how to copy the KDE color scheme file to the local config.