### PR TITLE
Fix: Header inactive colours no longer v0.1.0

### DIFF
--- a/Frappe/CatppuccinFrappe.colors
+++ b/Frappe/CatppuccinFrappe.colors
@@ -60,20 +60,6 @@ ForegroundNormal=198,208,245
 ForegroundPositive=179,225,163
 ForegroundVisited=198,170,232
 
-[Colors:Header][Inactive]
-BackgroundAlternate=49,54,59
-BackgroundNormal=27,25,35
-DecorationFocus=61,174,233
-DecorationHover=61,174,233
-ForegroundActive=61,174,233
-ForegroundInactive=161,169,177
-ForegroundLink=29,153,243
-ForegroundNegative=218,68,83
-ForegroundNeutral=246,116,0
-ForegroundNormal=252,252,252
-ForegroundPositive=39,174,96
-ForegroundVisited=155,89,182
-
 [Colors:Selection]
 BackgroundAlternate=242,205,205
 BackgroundNormal=240,198,198

--- a/Latte/CatppuccinLatte.colors
+++ b/Latte/CatppuccinLatte.colors
@@ -60,20 +60,6 @@ ForegroundNormal=76,79,105
 ForegroundPositive=64,160,43
 ForegroundVisited=136,57,239
 
-[Colors:Header][Inactive]
-BackgroundAlternate=49,54,59
-BackgroundNormal=27,25,35
-DecorationFocus=61,174,233
-DecorationHover=61,174,233
-ForegroundActive=61,174,233
-ForegroundInactive=161,169,177
-ForegroundLink=29,153,243
-ForegroundNegative=218,68,83
-ForegroundNeutral=246,116,0
-ForegroundNormal=252,252,252
-ForegroundPositive=39,174,96
-ForegroundVisited=155,89,182
-
 [Colors:Selection]
 BackgroundAlternate=221,120,120
 BackgroundNormal=221,120,120

--- a/Macchiato/CatppuccinMacchiato.colors
+++ b/Macchiato/CatppuccinMacchiato.colors
@@ -60,20 +60,6 @@ ForegroundNormal=215,218,224
 ForegroundPositive=179,225,163
 ForegroundVisited=198,170,232
 
-[Colors:Header][Inactive]
-BackgroundAlternate=49,54,59
-BackgroundNormal=27,25,35
-DecorationFocus=61,174,233
-DecorationHover=61,174,233
-ForegroundActive=61,174,233
-ForegroundInactive=161,169,177
-ForegroundLink=29,153,243
-ForegroundNegative=218,68,83
-ForegroundNeutral=246,116,0
-ForegroundNormal=252,252,252
-ForegroundPositive=39,174,96
-ForegroundVisited=155,89,182
-
 [Colors:Selection]
 BackgroundAlternate=242,205,205
 BackgroundNormal=240,198,198

--- a/Mocha/CatppuccinMocha.colors
+++ b/Mocha/CatppuccinMocha.colors
@@ -60,20 +60,6 @@ ForegroundNormal=215,218,224
 ForegroundPositive=179,225,163
 ForegroundVisited=198,170,232
 
-[Colors:Header][Inactive]
-BackgroundAlternate=49,54,59
-BackgroundNormal=27,25,35
-DecorationFocus=61,174,233
-DecorationHover=61,174,233
-ForegroundActive=61,174,233
-ForegroundInactive=161,169,177
-ForegroundLink=29,153,243
-ForegroundNegative=218,68,83
-ForegroundNeutral=246,116,0
-ForegroundNormal=252,252,252
-ForegroundPositive=39,174,96
-ForegroundVisited=155,89,182
-
 [Colors:Selection]
 BackgroundAlternate=242,205,205
 BackgroundNormal=242,205,205


### PR DESCRIPTION
Header inactive colours were still using the old base colour. Fixed it so they use the normal header colours.