### PR TITLE
Improve install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,33 @@
   <img src="https://github.com/Prayag2/catppuccin_kde/blob/main/assets/ss.png"/>
 </p>
 
-## Usage
+## Installation
 
-1. `git clone https://github.com/catppuccin/kde`
-2. Choose a flavor.
-3. `cd kde/<your chosen flavor>`
-4. `mkdir -p ~/.local/share/color-schemes` (Only required if you never installed a color scheme to your user before)
-5. `cp Catppuccin*.colors ~/.local/share/color-schemes/`.
-6. `kpackagetool5 -i Catppuccin-*.tar.gz`.   
+1. `mkdir -p ~/.local/share/color-schemes`
+2. `git clone https://github.com/catppuccin/kde catppuccin-kde`
+
+### Install all flavors
+1. `cd catppuccin-kde`
+2. `find . -type f -name "*.colors" -exec cp "{}" ~/.local/share/color-schemes \;`
+3. `find . -type f -name "*.tar.gz" -exec kpackagetool5 -i "{}" \;`  
 You need a working internet connection for this to work. Make sure system settings is not running.
-7. `lookandfeeltool -a Catppuccin-<flavor>` or alternatively open system settings and choose the global theme
 
+### Install one flavor
+1. `cd catppuccin-kde/<your chosen flavor>`
+2. `cp Catppuccin*.colors ~/.local/share/color-schemes/`
+3. `kpackagetool5 -i Catppuccin-*.tar.gz`  
+You need a working internet connection for this to work. Make sure system settings is not running.
+4. `lookandfeeltool -a Catppuccin-<flavor>` or alternatively open system settings and choose the global theme
+
+## Update
+
+1. `cd catppuccin-kde`
+2. `git pull`
+3. Run the installation commands again, replacing `kpackagetool5 -i` with `kpackagetool5 -u`
 
   
 	 Notes:
-> 1. To get a material-like look, install [lightly application style](https://github.com/Luwx/Lightly) and select it from System Settings > Appearance >  Application Style > Lightly.
+> 1. To get a material-like look, install [Lightly application style](https://github.com/Luwx/Lightly) and select it from System Settings > Appearance >  Application Style > Lightly.
 > 
 > 2. If you do not like the new icon for the application launcher set by the lightly plasma theme, simply delete `~/.local/share/plasma/desktoptheme> > /lightly-plasma-git/icons`. This will make it switch to the default.
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@
 ## Usage
 
 1. `git clone https://github.com/catppuccin/kde`
-2. Choose a flavour.
-3. `cd kde/<your chosen flavor>.`
-4. `cp Catppuccin<your chosen flavor>.colors ~/.local/share/color-schemes/Catppuccin<your chosen flavor>.colors`.
-5. `kpackagetool5 -i Catppuccin-<your chosen flavor>.tar.gz`.   
+2. Choose a flavor.
+3. `cd kde/<your chosen flavor>`
+4. `cp Catppuccin*.colors ~/.local/share/color-schemes/`.
+5. `kpackagetool5 -i Catppuccin-*.tar.gz`.   
 You need an working internet connection for this to work. Make sure system settings is not running.
 6. `lookandfeeltool -a Catppuccin-<flavor>` or alternatively open system settings and choose the global theme
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@
 1. `git clone https://github.com/catppuccin/kde`
 2. Choose a flavor.
 3. `cd kde/<your chosen flavor>`
-4. `cp Catppuccin*.colors ~/.local/share/color-schemes/`.
-5. `kpackagetool5 -i Catppuccin-*.tar.gz`.   
-You need an working internet connection for this to work. Make sure system settings is not running.
-6. `lookandfeeltool -a Catppuccin-<flavor>` or alternatively open system settings and choose the global theme
+4. `mkdir -p ~/.local/share/color-schemes` (Only required if you never installed a color scheme to your user before)
+5. `cp Catppuccin*.colors ~/.local/share/color-schemes/`.
+6. `kpackagetool5 -i Catppuccin-*.tar.gz`.   
+You need a working internet connection for this to work. Make sure system settings is not running.
+7. `lookandfeeltool -a Catppuccin-<flavor>` or alternatively open system settings and choose the global theme
 
 
   

--- a/README.md
+++ b/README.md
@@ -34,17 +34,15 @@ You need a working internet connection for this to work. Make sure system settin
 You need a working internet connection for this to work. Make sure system settings is not running.
 4. `lookandfeeltool -a Catppuccin-<flavor>` or alternatively open system settings and choose the global theme
 
+### Notes
+1. To get a material-like look, install [Lightly application style](https://github.com/Luwx/Lightly) and select it from System Settings > Appearance >  Application Style > Lightly.
+2. If you do not like the new icon for the application launcher set by the Lightly Plasma theme, simply delete `~/.local/share/plasma/desktoptheme/lightly-plasma-git/icons`. This will make it switch to the default.
+
 ## Update
 
 1. `cd catppuccin-kde`
 2. `git pull`
 3. Run the installation commands again, replacing `kpackagetool5 -i` with `kpackagetool5 -u`
-
-  
-	 Notes:
-> 1. To get a material-like look, install [Lightly application style](https://github.com/Luwx/Lightly) and select it from System Settings > Appearance >  Application Style > Lightly.
-> 
-> 2. If you do not like the new icon for the application launcher set by the lightly plasma theme, simply delete `~/.local/share/plasma/desktoptheme> > /lightly-plasma-git/icons`. This will make it switch to the default.
 
 ## 💝 Thanks to
 


### PR DESCRIPTION
- `~/.local/share/color-schemes` might not exist if you did not install a color scheme before.
- Using globs to avoid repeating the flavor
- Add instructions to install all flavors
- Add instructions to update
- Change the cloned folder name to be `catppuccin-kde`

---
### Old comment

Off-topic: I think adding a command to install all variants would be nice, e.g. by using `find`:
```bash
find . -type f -name "*.colors" -exec cp "{}" ~/.local/share/color-schemes \;
find . -type f -name "*.tar.gz" -exec kpackagetool5 -i "{}" \;
```
Also, adding information about updating would be useful (Using `-u` for `kpackagetool5`)
Should I add that?