### PR TITLE
fix: rewrite install.sh in POSIX shell for portability

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,19 +1,15 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Syntax <Flavour = 1-4 > <Accent = 1-14> <WindowDec = 1/2> <Debug = global/color/splash/cursor>
 
-COLORDIR=~/.local/share/color-schemes
-AURORAEDIR=~/.local/share/aurorae/themes
-LOOKANDFEELDIR=~/.local/share/plasma/look-and-feel
-DESKTOPTHEMEDIR=~/.local/share/plasma/desktoptheme
-CURSORDIR=~/.local/share/icons
+COLORDIR="${XDG_DATA_DIR:-$HOME/.local/share}/color-schemes"
+AURORAEDIR="${XDG_DATA_DIR:-$HOME/.local/share}/aurorae/themes"
+LOOKANDFEELDIR="${XDG_DATA_DIR:-$HOME/.local/share}/plasma/look-and-feel"
+DESKTOPTHEMEDIR="${XDG_DATA_DIR:-$HOME/.local/share}/plasma/desktoptheme"
+CURSORDIR="${XDG_DATA_DIR:-$HOME/.local/share}/icons"
 
 echo "Creating theme directories.."
-mkdir -p $COLORDIR
-mkdir -p $AURORAEDIR
-mkdir -p $LOOKANDFEELDIR
-mkdir -p $DESKTOPTHEMEDIR
-mkdir -p $CURSORDIR
+mkdir -p "$COLORDIR" "$AURORAEDIR" "$LOOKANDFEELDIR" "$DESKTOPTHEMEDIR" "$CURSORDIR"
 mkdir ./dist
 
 # Fast install
@@ -25,37 +21,48 @@ DEBUGMODE="$4"
 
 clear
 
-if [[ "$1" == "" ]]; then
-    echo ""
-    echo "Choose flavor out of -
+if [ -z "$1" ]; then
+    cat <<EOF
+
+Choose flavor out of -
     1. Mocha
     2. Macchiato
     3. Frappé
     4. Latte
     (Type the number corresponding to said pallet)
-    "
+EOF
     read -r FLAVOUR
     clear
 fi
 
-if [[ $FLAVOUR == "1" ]]; then
-    echo "The pallet Mocha(1) was selected";
-    FLAVOURNAME="Mocha";
-elif [[ $FLAVOUR == "2" ]]; then
-    echo "The pallet Macchiato(2) was selected";
-    FLAVOURNAME="Macchiato";
-elif [[ $FLAVOUR == "3" ]]; then
-    echo "The pallet Frappe(3) was selected";
-    FLAVOURNAME="Frappe";
-elif [[ $FLAVOUR == "4" ]]; then
-    echo "The pallet Latte(4) was selected";
-    FLAVOURNAME="Latte";
-else echo "Not a valid flavour name" && exit;
-fi
-echo ""
+case "$FLAVOUR" in
+    1)
+        echo "The pallet Mocha(1) was selected"
+        FLAVOURNAME="Mocha"
+        ;;
+    2)
+        echo "The pallet Macchiato(2) was selected"
+        FLAVOURNAME="Macchiato"
+        ;;
+    3)
+        echo "The pallet Frappe(3) was selected"
+        FLAVOURNAME="Frappe"
+        ;;
+    4)
+        echo "The pallet Latte(4) was selected"
+        FLAVOURNAME="Latte"
+        ;;
+    *)
+        echo "Not a valid flavour name: $FLAVOUR"
+        exit 1
+        ;;
+esac
 
-if [[ "$2" == "" ]]; then
-    echo "Choose an accent -
+echo
+
+if [ -z "$2" ]; then
+    cat <<EOF
+Choose an accent -
     1. Rosewater
     2. Flamingo
     3. Pink
@@ -70,305 +77,272 @@ if [[ "$2" == "" ]]; then
     12. Sapphire
     13. Blue
     14. Lavender
-    "
+EOF
     read -r ACCENT
     clear
 fi
 
 # Sets accent based on the pallet selected (Best to fold this in your respective editor)
-if [[ $ACCENT == "1" ]]; then
-
-    if [[ $FLAVOUR == "1" ]]; then
-        ACCENTCOLOR="245,224,220"
-    elif [[ $FLAVOUR == "2" ]]; then
-        ACCENTCOLOR="244,219,214"
-    elif [[ $FLAVOUR == "3" ]]; then
-        ACCENTCOLOR="242,213,207"
-    elif [[ $FLAVOUR == "4" ]]; then
-        ACCENTCOLOR="220,138,120"
-    fi
-    echo "Accent Rosewater(1) was selected!"
-    ACCENTNAME="Rosewater"
-elif [[ $ACCENT == "2" ]]; then
-    if [[ $FLAVOUR == "1" ]]; then
-        ACCENTCOLOR="242,205,205"
-    elif [[ $FLAVOUR == "2" ]]; then
-        ACCENTCOLOR="240,198,198"
-    elif [[ $FLAVOUR == "3" ]]; then
-        ACCENTCOLOR="238,190,190"
-    elif [[ $FLAVOUR == "4" ]]; then
-        ACCENTCOLOR="221,120,120"
-    fi
-    echo "Accent Flamingo(2) was selected!"
-    ACCENTNAME="Flamingo"
-elif [[ $ACCENT == "3" ]]; then
-    if [[ $FLAVOUR == "1" ]]; then
-        ACCENTCOLOR="245,194,231"
-    elif [[ $FLAVOUR == "2" ]]; then
-        ACCENTCOLOR="245,189,230"
-    elif [[ $FLAVOUR == "3" ]]; then
-        ACCENTCOLOR="244,184,228"
-    elif [[ $FLAVOUR == "4" ]]; then
-        ACCENTCOLOR="234,118,203"
-    fi
-    echo "Accent Pink(3) was selected!"
-    ACCENTNAME="Pink"
-elif [[ $ACCENT == "4" ]]; then
-    if [[ $FLAVOUR == "1" ]]; then
-        ACCENTCOLOR="203,166,247"
-    elif [[ $FLAVOUR == "2" ]]; then
-        ACCENTCOLOR="198,160,246"
-    elif [[ $FLAVOUR == "3" ]]; then
-        ACCENTCOLOR="202,158,230"
-    elif [[ $FLAVOUR == "4" ]]; then
-        ACCENTCOLOR="136,57,239"
-    fi
-    echo "Accent Mauve(4) was selected!"
-    ACCENTNAME="Mauve"
-elif [[ $ACCENT == "5" ]]; then
-    if [[ $FLAVOUR == "1" ]]; then
-        ACCENTCOLOR="243,139,168"
-    elif [[ $FLAVOUR == "2" ]]; then
-        ACCENTCOLOR="237,135,150"
-    elif [[ $FLAVOUR == "3" ]]; then
-        ACCENTCOLOR="231,130,132"
-    elif [[ $FLAVOUR == "4" ]]; then
-        ACCENTCOLOR="210,15,57"
-    fi
-    echo "Accent Red(5) was selected!"
-    ACCENTNAME="Red"
-elif [[ $ACCENT == "6" ]]; then
-    if [[ $FLAVOUR == "1" ]]; then
-        ACCENTCOLOR="235,160,172"
-    elif [[ $FLAVOUR == "2" ]]; then
-        ACCENTCOLOR="238,153,160"
-    elif [[ $FLAVOUR == "3" ]]; then
-        ACCENTCOLOR="234,153,156"
-    elif [[ $FLAVOUR == "4" ]]; then
-        ACCENTCOLOR="230,69,83"
-    fi
-    echo "Accent Maroon(6) was selected!"
-    ACCENTNAME="Maroon"
-elif [[ $ACCENT == "7" ]]; then
-    if [[ $FLAVOUR == "1" ]]; then
-        ACCENTCOLOR="250,179,135"
-    elif [[ $FLAVOUR == "2" ]]; then
-        ACCENTCOLOR="245,169,127"
-    elif [[ $FLAVOUR == "3" ]]; then
-        ACCENTCOLOR="239,159,118"
-    elif [[ $FLAVOUR == "4" ]]; then
-        ACCENTCOLOR="254,100,11"
-    fi
-    echo "Accent Peach(7) was selected!"
-    ACCENTNAME="Peach"
-elif [[ $ACCENT == "8" ]]; then
-    if [[ $FLAVOUR == "1" ]]; then
-        ACCENTCOLOR="249,226,175"
-    elif [[ $FLAVOUR == "2" ]]; then
-        ACCENTCOLOR="238,212,159"
-    elif [[ $FLAVOUR == "3" ]]; then
-        ACCENTCOLOR="229,200,144"
-    elif [[ $FLAVOUR == "4" ]]; then
-        ACCENTCOLOR="223,142,29"
-    fi
-    echo "Accent Yellow(8) was selected!"
-    ACCENTNAME="Yellow"
-elif [[ $ACCENT == "9" ]]; then
-    if [[ $FLAVOUR == "1" ]]; then
-        ACCENTCOLOR="166,227,161"
-    elif [[ $FLAVOUR == "2" ]]; then
-        ACCENTCOLOR="166,218,149"
-    elif [[ $FLAVOUR == "3" ]]; then
-        ACCENTCOLOR="166,209,137"
-    elif [[ $FLAVOUR == "4" ]]; then
-        ACCENTCOLOR="64,160,43"
-    fi
-    echo "Accent Green(9) was selected!"
-    ACCENTNAME="Green"
-elif [[ $ACCENT == "10" ]]; then
-    if [[ $FLAVOUR == "1" ]]; then
-        ACCENTCOLOR="148,226,213"
-    elif [[ $FLAVOUR == "2" ]]; then
-        ACCENTCOLOR="139,213,202"
-    elif [[ $FLAVOUR == "3" ]]; then
-        ACCENTCOLOR="129,200,190"
-    elif [[ $FLAVOUR == "4" ]]; then
-        ACCENTCOLOR="23,146,153"
-    fi
-    echo "Accent Teal(10) was selected!"
-    ACCENTNAME="Teal"
-elif [[ $ACCENT == "11" ]]; then
-    if [[ $FLAVOUR == "1" ]]; then
-        ACCENTCOLOR="137,220,235"
-    elif [[ $FLAVOUR == "2" ]]; then
-        ACCENTCOLOR="145,215,227"
-    elif [[ $FLAVOUR == "3" ]]; then
-        ACCENTCOLOR="153,209,219"
-    elif [[ $FLAVOUR == "4" ]]; then
-        ACCENTCOLOR="4,165,229"
-    fi
-    echo "Accent Sky(11) was selected!"
-    ACCENTNAME="Sky"
-elif [[ $ACCENT == "12" ]]; then
-    if [[ $FLAVOUR == "1" ]]; then
-        ACCENTCOLOR="116,199,236"
-    elif [[ $FLAVOUR == "2" ]]; then
-        ACCENTCOLOR="125,196,228"
-    elif [[ $FLAVOUR == "3" ]]; then
-        ACCENTCOLOR="133,193,220"
-    elif [[ $FLAVOUR == "4" ]]; then
-        ACCENTCOLOR="32,159,181"
-    fi
-    echo "Accent Sapphire(12) was selected!"
-    ACCENTNAME="Sapphire"
-elif [[ $ACCENT == "13" ]]; then
-    if [[ $FLAVOUR == "1" ]]; then
-        ACCENTCOLOR="137,180,250"
-    elif [[ $FLAVOUR == "2" ]]; then
-        ACCENTCOLOR="138,173,244"
-    elif [[ $FLAVOUR == "3" ]]; then
-        ACCENTCOLOR="140,170,238"
-    elif [[ $FLAVOUR == "4" ]]; then
-        ACCENTCOLOR="30,102,245"
-    fi
-    echo "Accent Blue(13) was selected!"
-    ACCENTNAME="Blue"
-elif [[ $ACCENT == "14" ]]; then
-    if [[ $FLAVOUR == "1" ]]; then
-        ACCENTCOLOR="180,190,254"
-    elif [[ $FLAVOUR == "2" ]]; then
-        ACCENTCOLOR="183,189,248"
-    elif [[ $FLAVOUR == "3" ]]; then
-        ACCENTCOLOR="186,187,241"
-    elif [[ $FLAVOUR == "4" ]]; then
-        ACCENTCOLOR="114,135,253"
-    fi
-    echo "Accent Lavender(14) was selected!"
-    ACCENTNAME="Lavender"
-else echo "Not a valid accent" && exit
-fi
+case "$ACCENT" in
+    1)
+        case "$FLAVOUR" in
+            1) ACCENTCOLOR="245,224,220" ;;
+            2) ACCENTCOLOR="244,219,214" ;;
+            3) ACCENTCOLOR="242,213,207" ;;
+            4) ACCENTCOLOR="220,138,120" ;;
+        esac
+        echo "Accent Rosewater(1) was selected!"
+        ACCENTNAME="Rosewater"
+        ;;
+    2)
+        case "$FLAVOUR" in
+            1) ACCENTCOLOR="242,205,205" ;;
+            2) ACCENTCOLOR="240,198,198" ;;
+            3) ACCENTCOLOR="238,190,190" ;;
+            4) ACCENTCOLOR="221,120,120" ;;
+        esac
+        echo "Accent Flamingo(2) was selected!"
+        ACCENTNAME="Flamingo"
+        ;;
+    3)
+        case "$FLAVOUR" in
+            1) ACCENTCOLOR="245,194,231" ;;
+            2) ACCENTCOLOR="245,189,230" ;;
+            3) ACCENTCOLOR="244,184,228" ;;
+            4) ACCENTCOLOR="234,118,203" ;;
+        esac
+        echo "Accent Pink(3) was selected!"
+        ACCENTNAME="Pink"
+        ;;
+    4)
+        case "$FLAVOUR" in
+            1) ACCENTCOLOR="203,166,247" ;;
+            2) ACCENTCOLOR="198,160,246" ;;
+            3) ACCENTCOLOR="202,158,230" ;;
+            4) ACCENTCOLOR="136,57,239" ;;
+        esac
+        echo "Accent Mauve(4) was selected!"
+        ACCENTNAME="Mauve"
+        ;;
+    5)
+        case "$FLAVOUR" in
+            1) ACCENTCOLOR="243,139,168" ;;
+            2) ACCENTCOLOR="237,135,150" ;;
+            3) ACCENTCOLOR="231,130,132" ;;
+            4) ACCENTCOLOR="210,15,57" ;;
+        esac
+        echo "Accent Red(5) was selected!"
+        ACCENTNAME="Red"
+        ;;
+    6)
+        case "$FLAVOUR" in
+            1) ACCENTCOLOR="235,160,172" ;;
+            2) ACCENTCOLOR="238,153,160" ;;
+            3) ACCENTCOLOR="234,153,156" ;;
+            4) ACCENTCOLOR="230,69,83" ;;
+        esac
+        echo "Accent Maroon(6) was selected!"
+        ACCENTNAME="Maroon"
+        ;;
+    7)
+        case "$FLAVOUR" in
+            1) ACCENTCOLOR="250,179,135" ;;
+            2) ACCENTCOLOR="245,169,127" ;;
+            3) ACCENTCOLOR="239,159,118" ;;
+            4) ACCENTCOLOR="254,100,11" ;;
+        esac
+        echo "Accent Peach(7) was selected!"
+        ACCENTNAME="Peach"
+        ;;
+    8)
+        case "$FLAVOUR" in
+            1) ACCENTCOLOR="249,226,175" ;;
+            2) ACCENTCOLOR="238,212,159" ;;
+            3) ACCENTCOLOR="229,200,144" ;;
+            4) ACCENTCOLOR="223,142,29" ;;
+        esac
+        echo "Accent Yellow(8) was selected!"
+        ACCENTNAME="Yellow"
+        ;;
+    9)
+        case "$FLAVOUR" in
+            1) ACCENTCOLOR="166,227,161" ;;
+            2) ACCENTCOLOR="166,218,149" ;;
+            3) ACCENTCOLOR="166,209,137" ;;
+            4) ACCENTCOLOR="64,160,43" ;;
+        esac
+        echo "Accent Green(9) was selected!"
+        ACCENTNAME="Green"
+        ;;
+    10)
+        case "$FLAVOUR" in
+            1) ACCENTCOLOR="148,226,213" ;;
+            2) ACCENTCOLOR="139,213,202" ;;
+            3) ACCENTCOLOR="129,200,190" ;;
+            4) ACCENTCOLOR="23,146,153" ;;
+        esac
+        echo "Accent Teal(10) was selected!"
+        ACCENTNAME="Teal"
+        ;;
+    11)
+        case "$FLAVOUR" in
+            1) ACCENTCOLOR="137,220,235" ;;
+            2) ACCENTCOLOR="145,215,227" ;;
+            3) ACCENTCOLOR="153,209,219" ;;
+            4) ACCENTCOLOR="4,165,229" ;;
+        esac
+        echo "Accent Sky(11) was selected!"
+        ACCENTNAME="Sky"
+        ;;
+    12)
+        case "$FLAVOUR" in
+            1) ACCENTCOLOR="116,199,236" ;;
+            2) ACCENTCOLOR="125,196,228" ;;
+            3) ACCENTCOLOR="133,193,220" ;;
+            4) ACCENTCOLOR="32,159,181" ;;
+        esac
+        echo "Accent Sapphire(12) was selected!"
+        ACCENTNAME="Sapphire"
+        ;;
+    13)
+        case "$FLAVOUR" in
+            1) ACCENTCOLOR="137,180,250" ;;
+            2) ACCENTCOLOR="138,173,244" ;;
+            3) ACCENTCOLOR="140,170,238" ;;
+            4) ACCENTCOLOR="30,102,245" ;;
+        esac
+        echo "Accent Blue(13) was selected!"
+        ACCENTNAME="Blue"
+        ;;
+    14)
+        case "$FLAVOUR" in
+            1) ACCENTCOLOR="180,190,254" ;;
+            2) ACCENTCOLOR="183,189,248" ;;
+            3) ACCENTCOLOR="186,187,241" ;;
+            4) ACCENTCOLOR="114,135,253" ;;
+        esac
+        echo "Accent Lavender(14) was selected!"
+        ACCENTNAME="Lavender"
+        ;;
+    *)
+        echo "Not a valid accent: $ACCENT"
+        exit 1
+        ;;
+esac
 
 GLOBALTHEMENAME="Catppuccin-$FLAVOURNAME-$ACCENTNAME"
 SPLASHSCREENNAME="Catppuccin-$FLAVOURNAME-$ACCENTNAME-splash"
 
-if [[ "$3" == "" ]]; then
-    echo "Choose window decoration style -
+if [ -z "$3" ]; then
+    cat <<EOF
+Choose window decoration style -
     1. Modern (Mixed)
     2. Classic (MacOS like)
-    "
+EOF
     read -r WINDECSTYLE
     clear
 fi
 
-if [[ $WINDECSTYLE == "1" ]]; then
-    WINDECSTYLENAME=Modern
-    WINDECSTYLECODE=__aurorae__svg__Catppuccin"$FLAVOURNAME"-Modern
-
-    if [[ $FLAVOUR == "1" ]]; then
-    StoreAuroraeNo="2023219";
-    elif [[ $FLAVOUR == "2" ]]; then
-    StoreAuroraeNo="2023220";
-    elif [[ $FLAVOUR == "3" ]]; then
-    StoreAuroraeNo="2023222";
-    elif [[ $FLAVOUR == "4" ]]; then
-    StoreAuroraeNo="2023224";
-    fi
-
-    echo "Hey! thanks for picking 'Modern', this one has a few rules or else it might break
+case "$WINDECSTYLE" in
+    1)
+        WINDECSTYLENAME=Modern
+        WINDECSTYLECODE=__aurorae__svg__Catppuccin"$FLAVOURNAME"-Modern
+    
+        case "$FLAVOUR" in
+            1) StoreAuroraeNo="2023219" ;;
+            2) StoreAuroraeNo="2023220" ;;
+            3) StoreAuroraeNo="2023222" ;;
+            4) StoreAuroraeNo="2023224" ;;
+        esac
+    
+        cat <<EOF
+Hey! thanks for picking 'Modern', this one has a few rules or else it might break
  1: Use 3 icons on the right, With the 'Close' Button on the Far-Right
- 2: If you would like the pin on all desktops button, You need to place it on the left."
-    echo "We apologize if you wanted a different configuration :("
-    sleep 2
+ 2: If you would like the pin on all desktops button, You need to place it on the left.
+We apologize if you wanted a different configuration :(
+EOF
+        sleep 2
+        ;;
+    2)
+        WINDECSTYLENAME=Classic
+        WINDECSTYLECODE=__aurorae__svg__Catppuccin"$FLAVOURNAME"-Classic
+    
+        case "$FLAVOUR" in
+            1) StoreAuroraeNo="2023180" ;;
+            2) StoreAuroraeNo="2023202" ;;
+            3) StoreAuroraeNo="2023203" ;;
+            4) StoreAuroraeNo="2023217" ;;
+        esac
+        ;;
+    *) echo "Not a valid Window decoration" ;;
+esac
 
-elif [[ $WINDECSTYLE == "2" ]]; then
-    WINDECSTYLENAME=Classic
-    WINDECSTYLECODE=__aurorae__svg__Catppuccin"$FLAVOURNAME"-Classic
+ModifyLightlyPlasma() {
 
-    if [[ $FLAVOUR == "1" ]]; then
-    StoreAuroraeNo="2023180";
-    elif [[ $FLAVOUR == "2" ]]; then
-    StoreAuroraeNo="2023202";
-    elif [[ $FLAVOUR == "3" ]]; then
-    StoreAuroraeNo="2023203";
-    elif [[ $FLAVOUR == "4" ]]; then
-    StoreAuroraeNo="2023217";
-    fi
-
-else
-    echo "Not a valid Window decoration"
-fi
-
-function ModifyLightlyPlasma {
-
-    rm -rf $DESKTOPTHEMEDIR/lightly-plasma-git/icons/*
-    rm -rf $DESKTOPTHEMEDIR/lightly-plasma-git/translucent
-    rm $DESKTOPTHEMEDIR/lightly-plasma-git/widgets/tabbar.svgz
-    rm $DESKTOPTHEMEDIR/lightly-plasma-git/dialogs/background.svgz
+    rm -rf "$DESKTOPTHEMEDIR"/lightly-plasma-git/icons/*
+    rm -rf "$DESKTOPTHEMEDIR"/lightly-plasma-git/translucent
+    rm "$DESKTOPTHEMEDIR"/lightly-plasma-git/widgets/tabbar.svgz
+    rm "$DESKTOPTHEMEDIR"/lightly-plasma-git/dialogs/background.svgz
 
     # Copy Patches
-    cp $DESKTOPTHEMEDIR/lightly-plasma-git/solid/* $DESKTOPTHEMEDIR/lightly-plasma-git -Rf
-    cp ./Patches/glowbar.svg $DESKTOPTHEMEDIR/lightly-plasma-git/widgets -rf
-    cp ./Patches/background.svg $DESKTOPTHEMEDIR/lightly-plasma-git/widgets -rf
-    cp ./Patches/panel-background.svgz $DESKTOPTHEMEDIR/lightly-plasma-git/widgets
+    cp -rf "$DESKTOPTHEMEDIR"/lightly-plasma-git/solid/* "$DESKTOPTHEMEDIR"/lightly-plasma-git
+    cp -rf ./Patches/glowbar.svg "$DESKTOPTHEMEDIR"/lightly-plasma-git/widgets
+    cp -rf ./Patches/background.svg "$DESKTOPTHEMEDIR"/lightly-plasma-git/widgets
+    cp ./Patches/panel-background.svgz "$DESKTOPTHEMEDIR"/lightly-plasma-git/widgets
 
     # Modify description to state that it has been modified by the KDE Catppuccin Installer
-    sed -e s/A\ plasma\ style\ with\ close\ to\ the\ look\ of\ the\ newest\ Lightly./*MODIFIED\ BY\ CATPPUCCIN\ KDE\ INSTALLER*\ A\ plasma\ style\ with\ close\ to\ the\ look\ of\ the\ newest\ Lightly./g $DESKTOPTHEMEDIR/lightly-plasma-git/metadata.desktop >> $DESKTOPTHEMEDIR/lightly-plasma-git/newMetadata.desktop
-    cp -f $DESKTOPTHEMEDIR/metadata.desktop $DESKTOPTHEMEDIR/lightly-plasma-git/metadata.desktop && rm $DESKTOPTHEMEDIR/metadata.desktop
+    sed -i 's/A plasma style with close to the look of the newest Lightly./*MODIFIED BY CATPPUCCIN KDE INSTALLER* &/g' "$DESKTOPTHEMEDIR"/lightly-plasma-git/metadata.desktop
+    cp -f "$DESKTOPTHEMEDIR"/metadata.desktop "$DESKTOPTHEMEDIR"/lightly-plasma-git/metadata.desktop
+    rm "$DESKTOPTHEMEDIR"/metadata.desktop
 }
 
-function BuildColorscheme {
-
+BuildColorscheme() {
     # Add Metadata & Replace Accent in colors file
-    sed -e s/--accentColor/$ACCENTCOLOR/g -e s/--flavour/$FLAVOURNAME/g -e s/--accentName/$ACCENTNAME/g ./Resources/Base.colors > ./dist/base.colors
+    sed "s/--accentColor/$ACCENTCOLOR/g; s/--flavour/$FLAVOURNAME/g; s/--accentName/$ACCENTNAME/g" ./Resources/Base.colors > ./dist/base.colors
     # Hydrate Dummy colors according to Pallet
-    FLAVOURNAME=$FLAVOURNAME ./Installer/color-build.sh -o ./dist/Catppuccin$FLAVOURNAME$ACCENTNAME.colors -s ./dist/base.colors
+    FLAVOURNAME="$FLAVOURNAME" ./Installer/color-build.sh -o ./dist/Catppuccin"$FLAVOURNAME$ACCENTNAME".colors -s ./dist/base.colors
 }
 
-function BuildSplashScreen {
-
-    if [[ $FLAVOUR == "1" ]]; then
-        MANTLECOLOR=#181825
-    elif [[ $FLAVOUR == "2" ]]; then
-        MANTLECOLOR=#1e2030
-    elif [[ $FLAVOUR == "3" ]]; then
-        MANTLECOLOR=#292c3c
-    elif [[ $FLAVOUR == "4" ]]; then
-        MANTLECOLOR=#e6e9ef
-    fi
+BuildSplashScreen() {
+    case "$FLAVOUR" in
+        1) MANTLECOLOR="#181825" ;;
+        2) MANTLECOLOR="#1e2030" ;;
+        3) MANTLECOLOR="#292c3c" ;;
+        4) MANTLECOLOR="#e6e9ef" ;;
+    esac
 
     # Hydrate Dummy colors according to Pallet
-    FLAVOURNAME=$FLAVOURNAME ./Installer/color-build.sh -s ./Resources/splash-screen/contents/splash/images/busywidget.svg -o ./dist/$SPLASHSCREENNAME/contents/splash/images/_busywidget.svg
+    FLAVOURNAME="$FLAVOURNAME" ./Installer/color-build.sh -s ./Resources/splash-screen/contents/splash/images/busywidget.svg -o ./dist/"$SPLASHSCREENNAME"/contents/splash/images/_busywidget.svg
     # Replace Accent in colors file
-    sed ./dist/"$SPLASHSCREENNAME"/contents/splash/images/_busywidget.svg -e s/REPLACE--ACCENT/$ACCENTCOLOR/g > ./dist/"$SPLASHSCREENNAME"/contents/splash/images/busywidget.svg
+    sed "s/REPLACE--ACCENT/$ACCENTCOLOR/g" ./dist/"$SPLASHSCREENNAME"/contents/splash/images/_busywidget.svg > ./dist/"$SPLASHSCREENNAME"/contents/splash/images/busywidget.svg
     # Cleanup temporary file
     rm ./dist/"$SPLASHSCREENNAME"/contents/splash/images/_busywidget.svg
 
     # Hydrate Dummy colors according to Pallet (QML file)
     sed -e s/REPLACE--MANTLE/"$MANTLECOLOR"/g ./Resources/splash-screen/contents/splash/Splash.qml > ./dist/"$SPLASHSCREENNAME"/contents/splash/Splash.qml
     # Add CTP Logo
-    if [[ $FLAVOUR != "4" ]]; then
+    if [ "$FLAVOUR" -ne 4 ]; then
         cp ./Resources/splash-screen/contents/splash/images/Logo.png ./dist/"$SPLASHSCREENNAME"/contents/splash/images/Logo.png
     else
         cp ./Resources/splash-screen/contents/splash/images/Latte_Logo.png ./dist/"$SPLASHSCREENNAME"/contents/splash/images/Logo.png
     fi
-    sed -e s/--accentName/"$ACCENTNAME"/g -e s/--flavour/"$FLAVOURNAME"/g ./Resources/splash-screen/metadata.desktop > ./dist/"$SPLASHSCREENNAME"/metadata.desktop
+    sed "s/--accentName/$ACCENTNAME/g; s/--flavour/$FLAVOURNAME/g" ./Resources/splash-screen/metadata.desktop > ./dist/"$SPLASHSCREENNAME"/metadata.desktop
     mkdir ./dist/"$SPLASHSCREENNAME"/contents/previews
     cp ./Resources/splash-previews/"$FLAVOURNAME".png ./dist/"$SPLASHSCREENNAME"/contents/previews/splash.png
     cp ./Resources/splash-previews/"$FLAVOURNAME".png ./dist/"$SPLASHSCREENNAME"/contents/previews/preview.png
-    cp -r ./dist/"$SPLASHSCREENNAME" ~/.local/share/plasma/look-and-feel/
+    cp -r ./dist/"$SPLASHSCREENNAME" "${XDG_DATA_DIR:-$HOME/.local/share}"/plasma/look-and-feel/
 }
 
-function InstallGlobalTheme {
-
+InstallGlobalTheme() {
     # Prepare Global Theme Folder
     cp -r ./Resources/LookAndFeel/Catppuccin-"$FLAVOURNAME"-Global ./dist/"$GLOBALTHEMENAME"
     mkdir -p ./dist/"$SPLASHSCREENNAME"/contents/splash/images
 
     # Hydrate Metadata with Pallet + Accent Info
-    sed -e s/--accentName/"$ACCENTNAME"/g -e s/--flavour/"$FLAVOURNAME"/g -e s/--StoreAuroraeNo/"$StoreAuroraeNo"/g ./Resources/LookAndFeel/metadata.desktop > ./dist/Catppuccin-"$FLAVOURNAME"-"$ACCENTNAME"/metadata.desktop
+    sed "s/--accentName/$ACCENTNAME/g; s/--flavour/$FLAVOURNAME/g; s/--StoreAuroraeNo/$StoreAuroraeNo/g" ./Resources/LookAndFeel/metadata.desktop > ./dist/Catppuccin-"$FLAVOURNAME"-"$ACCENTNAME"/metadata.desktop
 
     # Modify 'defaults' to set the correct Aurorae Theme
-    sed -e s/--accentName/"$ACCENTNAME"/g -e s/--flavour/"$FLAVOURNAME"/g -e s/--aurorae/"$WINDECSTYLECODE"/g ./Resources/LookAndFeel/defaults > ./dist/Catppuccin-"$FLAVOURNAME"-"$ACCENTNAME"/contents/defaults
+    sed "s/--accentName/$ACCENTNAME/g; s/--flavour/$FLAVOURNAME/g; s/--aurorae/$WINDECSTYLECODE/g" ./Resources/LookAndFeel/defaults > ./dist/Catppuccin-"$FLAVOURNAME"-"$ACCENTNAME"/contents/defaults
 
     # Build SplashScreen
     echo "Building SplashScreen.."
@@ -378,32 +352,38 @@ function InstallGlobalTheme {
     # This refers to the QDBusConnection: error: could not send signal to service error
     # Which has had no effect in our testing on the working of this Installer.
 
-    echo "
+    cat <<EOF
+
  WARNING: There might be some errors that might not affect the installer at all during this step, Please advise.
-    "
+ 
+EOF
     sleep 1
     echo "Installing Global Theme.."
-    cd ./dist && tar -cf "$GLOBALTHEMENAME".tar.gz "$GLOBALTHEMENAME"
+    cd ./dist
+    tar -cf "$GLOBALTHEMENAME".tar.gz "$GLOBALTHEMENAME"
     kpackagetool5 -i "$GLOBALTHEMENAME".tar.gz
     cd ..
 
-    if [[ ! -d "$DESKTOPTHEMEDIR/lightly-plasma-git/" ]]; then
+    if [ ! -d "$DESKTOPTHEMEDIR/lightly-plasma-git/" ]; then
         clear
-        echo ""
-        echo "Installation failed, could not fetch the lightly plasma theme lightly-plasma-git from store.kde.org"
-        echo "Here are some things you can do to try fixing this:"
-        echo " 1: Rerunning the install script"
-        echo " 2: Check your intenet connection"
-        echo " 3: See if https://store.kde.org is blocked"
-        echo " 4: Manually installing Lightly-Plasma from https://pling.com/p/1879921/"
-        echo ""
-        echo "Would you like to install Catppuccin/KDE without lightly plasma? [y/n]:"
+        cat <<EOF
+
+Installation failed, could not fetch the lightly plasma theme lightly-plasma-git from store.kde.org
+Here are some things you can do to try fixing this:
+ 1: Rerunning the install script
+ 2: Check your intenet connection
+ 3: See if https://store.kde.org is blocked
+ 4: Manually installing Lightly-Plasma from https://pling.com/p/1879921/
+
+Would you like to install Catppuccin/KDE without lightly plasma? [Y/n]:
+EOF
         read -r CONFIRMATION
-        if [[ $CONFIRMATION == "N" ]] || [[ $CONFIRMATION == "n" ]]; then
-            echo ""
-            echo "Exiting..." && exit
+        if[[ "$CONFIRMATION" = "N" ] || [ "$CONFIRMATION" = "n" ]; then
+            echo
+            echo "Exiting..."
+            exit
         fi
-        echo ""
+        echo
         echo "Continuing without lightly plasma.."
     else
         echo "Modifying lightly plasma theme.."
@@ -411,7 +391,7 @@ function InstallGlobalTheme {
     fi
 }
 
-function InstallColorscheme {
+InstallColorscheme() {
     echo "Building Colorscheme.."
 
     # Generate Color scheme
@@ -419,54 +399,57 @@ function InstallColorscheme {
 
     # Install Colorscheme
     echo "Installing Colorscheme.."
-    mv ./dist/Catppuccin"$FLAVOURNAME$ACCENTNAME".colors $COLORDIR
+    mv ./dist/Catppuccin"$FLAVOURNAME$ACCENTNAME".colors "$COLORDIR"
 }
 
-function GetCursor {
+GetCursor() {
     # Fetches cursors
     echo "Downloading Catppuccin Cursors from Catppuccin/cursors..."
-    sleep 1.5
+    sleep 2
     wget -P ./dist https://github.com/catppuccin/cursors/releases/download/v0.2.0/Catppuccin-"$FLAVOURNAME"-"$ACCENTNAME"-Cursors.zip
     wget -P ./dist https://github.com/catppuccin/cursors/releases/download/v0.2.0/Catppuccin-"$FLAVOURNAME"-Dark-Cursors.zip
-    cd ./dist && unzip Catppuccin-"$FLAVOURNAME"-"$ACCENTNAME"-Cursors.zip
+    cd ./dist
+    unzip Catppuccin-"$FLAVOURNAME"-"$ACCENTNAME"-Cursors.zip
     unzip Catppuccin-"$FLAVOURNAME"-Dark-Cursors.zip
     cd ..
 }
 
-function InstallCursor {
+InstallCursor() {
     GetCursor
-    mv ./dist/Catppuccin-"$FLAVOURNAME"-"$ACCENTNAME"-Cursors $CURSORDIR
-    mv ./dist/Catppuccin-"$FLAVOURNAME"-Dark-Cursors $CURSORDIR
+    mv ./dist/Catppuccin-"$FLAVOURNAME"-"$ACCENTNAME"-Cursors "$CURSORDIR"
+    mv ./dist/Catppuccin-"$FLAVOURNAME"-Dark-Cursors "$CURSORDIR"
 }
 
 # Syntax <Flavour> <Accent> <WindowDec> <Debug = global/color/splash/cursor>
-if [[ $DEBUGMODE == "" ]]; then
-    echo ""
-    echo "Install $FLAVOURNAME $ACCENTNAME? with the $WINDECSTYLENAME window Decorations? [y/n]:"
-    read -r CONFIRMATION
-    clear
-elif [[ $DEBUGMODE == "global" ]]; then
-    InstallGlobalTheme
-    exit
-elif [[ $DEBUGMODE == "color" ]]; then
-    BuildColorscheme
-    exit
-elif [[ $DEBUGMODE == "splash" ]]; then
-    # Prepare Global Theme Folder
-    GLOBALTHEMENAME="Catppuccin-$FLAVOURNAME-$ACCENTNAME"
+case "$DEBUGMODE" in
+    "")
+        echo
+        echo "Install $FLAVOURNAME $ACCENTNAME? with the $WINDECSTYLENAME window Decorations? [y/N]:"
+        read -r CONFIRMATION
+        clear
+        ;;
+    global)
+        InstallGlobalTheme
+        exit
+        ;;
+    color)
+        BuildColorscheme
+        exit
+        ;;
+    splash)
+        # Prepare Global Theme Folder
+        GLOBALTHEMENAME="Catppuccin-$FLAVOURNAME-$ACCENTNAME"
 
-    cp -r ./Resources/LookAndFeel/Catppuccin-"$FLAVOURNAME"-Global ./dist/"$GLOBALTHEMENAME"
-    mkdir -p ./dist/"$GLOBALTHEMENAME"/contents/splash/images
+        cp -r ./Resources/LookAndFeel/Catppuccin-"$FLAVOURNAME"-Global ./dist/"$GLOBALTHEMENAME"
+        mkdir -p ./dist/"$GLOBALTHEMENAME"/contents/splash/images
 
-    BuildSplashScreen
-elif [[ $DEBUGMODE == "cursor" ]]; then
-    GetCursor
-else
-    echo "Invalid Debug Mode"
-fi
+        BuildSplashScreen
+        ;;
+    cursor) GetCursor ;;
+    *) echo "Invalid Debug Mode" ;;
+esac
 
-if [[ $CONFIRMATION == "Y" ]] || [[ $CONFIRMATION == "y" ]]; then
-
+if [ "$CONFIRMATION" = "Y" ]] || [ "$CONFIRMATION" = "y" ]; then
     # Build and Install Global Theme
     InstallGlobalTheme
 
@@ -481,21 +464,23 @@ if [[ $CONFIRMATION == "Y" ]] || [[ $CONFIRMATION == "y" ]]; then
     rm -rf ./dist
 
     # Apply theme
-    echo ""
-    echo "Do you want to apply theme? [y/n]:"
+    echo
+    echo "Do you want to apply theme? [y/N]:"
     read -r CONFIRMATION
 
-    if [[ $CONFIRMATION == "Y" ]] || [[ $CONFIRMATION == "y" ]]; then
+    if [ "$CONFIRMATION" = "Y" ] || [ "$CONFIRMATION" == "y" ]; then
         lookandfeeltool -a "$GLOBALTHEMENAME"
         clear
-        echo "The cursors will fully apply once you log out"
-
         # Some legacy apps still look in ~/.icons
-        echo "You may want to run the following in your terminal if you notice any inconsistencies for the cursor theme"
-        echo "ln -s ~/.local/share/icons/ ~/.icons"
+        cat <<EOF
+The cursors will fully apply once you log out
+You may want to run the following in your terminal if you notice any inconsistencies for the cursor theme:
+ln -s ~/.local/share/icons/ ~/.icons
+EOF
     else
         echo "You can apply theme at any time using system settings"
-        sleep 0.5
+        sleep 1
     fi
-else echo "Exiting.." && exit
+else
+    echo "Exiting.."
 fi


### PR DESCRIPTION
Contrary to popular belief, bash is not universal on Linux systems.

- Check `$XDG_DATA_DIR`
- Replace multiline string literals with heredocs
- Replace Bash's `[[` with the universal `[`
- Use `case` instead of if-else chains where appropriate
- Quote some more variables
- Clean up sed scripts
- Indicate default choice in yes/no prompts
- Replace Bash functions with regular shell functions
- Don't sleep for fractional seconds (not all `sleep`s support fractional seconds)