### PR TITLE
Fix: Pass shellcheck and tweak readme

### DIFF
--- a/Installer/color-build.sh
+++ b/Installer/color-build.sh
@@ -1,35 +1,39 @@
-#!/bin/sh -eu
+#!/bin/sh
 
 # From github.com/skinatro/theme-tool
 
 help() {
-    cat <<EOF
+  cat <<EOF
 
-Usage: ${0##*/} -o <output> -s <source>
+Usage: ${0##*/} -o <output> -s <source> -f <flavour>
     -o <path> Output directory
     -s <path> Source file
+    -f <flavour>  Flavour name (Mocha, Macchiato, Frappe, Latte)
 EOF
-    exit 1 # Exit script after printing help  
+  exit 1 # Exit script after printing help
 }
 
-while getopts o:s: opt; do
-    case "$opt" in
-        o) OUT="$OPTARG" ;;
-        s) SOURCE="$OPTARG" ;;
-        ?) help ;; # Print help in case parameter is non-existent
-    esac
+while getopts o:s:f: opt; do
+  case "$opt" in
+    o) OUT="$OPTARG" ;;
+    s) SOURCE="$OPTARG" ;;
+    f) FLAVOURNAME="$OPTARG" ;;  # New case for -f
+    ?) help ;;
+  esac
 done
 
 # Print help in case parameters are empty
-if [ -z "$OUT" ] || [ -z "$SOURCE" ]; then
-    echo "Some or all of the parameters are empty"
-    help
+if [ -z "$OUT" ] || [ -z "$SOURCE" ] || [ -z "$FLAVOURNAME" ]; then
+  echo "Some or all of the parameters are empty"
+  help
 fi
 
 # no arrays due to posix compliancy
 if echo "$FLAVOURNAME" | grep -Evq 'Mocha|Macchiato|Frappe|Latte'; then
-    clear
-    echo "Invalid palette $FLAVOURNAME"
-    exit
+  clear
+  echo "Invalid palette $FLAVOURNAME"
+  exit
 fi
-sed -f Installer/Pallets/"$FLAVOURNAME".sed "$SOURCE" > "$OUT"
+
+FLAVOUR_SED="Installer/Pallets/${FLAVOURNAME}.sed"
+sed -f "$FLAVOUR_SED" "$SOURCE" > "$OUT"

--- a/README.md
+++ b/README.md
@@ -57,13 +57,11 @@
 The theme makes modifications to [doncsugar's](https://github.com/doncsugar) [lightly plasma style](https://github.com/doncsugar/lightly-plasma). It is licensed under GPL 3.0 and as such, all the changes to the plasma theme are also licensed under GPL. The MIT License still applies to the color scheme, splash screen and the window decorations theme.
 
 
-## 💝 Thanks to
+## 💝 Current Maintainer
+- [Sourcastic](https://github.com/Sourcastic)
 
+## 💖 Past Maintainers
 - [Prayag2](https://github.com/Prayag2)
-- [Sourcastic](https://github.com/Sourcastic)  
-- [Cequallium](https://github.com/Cequallium)
-- [justTOBBI](https://github.com/justTOBBI)
-
 
 
 &nbsp;

--- a/install.sh
+++ b/install.sh
@@ -3,9 +3,9 @@
 # Syntax <Flavour = 1-4 > <Accent = 1-14> <WindowDec = 1/2> <Debug = global/color/splash/cursor>
 
 check_command_exists() {
-  command_name="$@"
+  command_name="${*}"
 
-  if ! command -v "$command_name" &> /dev/null; then
+  if ! command -v "$command_name" >/dev/null 2>&1; then
     echo "Error: Dependency '$command_name' is not met."
     echo "Exiting.."
     exit 1
@@ -290,7 +290,7 @@ BuildColorscheme() {
     # Add Metadata & Replace Accent in colors file
     sed "s/--accentColor/$ACCENTCOLOR/g; s/--flavour/$FLAVOURNAME/g; s/--accentName/$ACCENTNAME/g" ./Resources/Base.colors > ./dist/base.colors
     # Hydrate Dummy colors according to Pallet
-    FLAVOURNAME="$FLAVOURNAME" ./Installer/color-build.sh -o ./dist/Catppuccin"$FLAVOURNAME$ACCENTNAME".colors -s ./dist/base.colors
+    ./Installer/color-build.sh -f "$FLAVOURNAME" -o ./dist/Catppuccin"$FLAVOURNAME$ACCENTNAME".colors -s ./dist/base.colors
 }
 
 BuildSplashScreen() {
@@ -350,7 +350,7 @@ EOF
     sleep 1
     echo "Installing Global Theme.."
     (
-        cd ./dist
+        cd ./dist || exit
         tar -cf "$GLOBALTHEMENAME".tar.gz "$GLOBALTHEMENAME"
         kpackagetool5 -i "$GLOBALTHEMENAME".tar.gz
     )
@@ -400,7 +400,7 @@ GetCursor() {
     wget -P ./dist https://github.com/catppuccin/cursors/releases/download/v0.2.0/Catppuccin-"$FLAVOURNAME"-"$ACCENTNAME"-Cursors.zip
     wget -P ./dist https://github.com/catppuccin/cursors/releases/download/v0.2.0/Catppuccin-"$FLAVOURNAME"-Dark-Cursors.zip
     (
-        cd ./dist
+        cd ./dist || exit
         unzip Catppuccin-"$FLAVOURNAME"-"$ACCENTNAME"-Cursors.zip
         unzip Catppuccin-"$FLAVOURNAME"-Dark-Cursors.zip
     )


### PR DESCRIPTION
Modifies install.sh and color-build.sh to pass shellcheck and edits readme to be in line with other parts of the org. (See: https://github.com/catppuccin/userstyles/tree/main/styles/instagram)