### PR TITLE
install.sh: added DEBUGMODE "auto" which installs and applies the KDE theme without user interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@
 1. `git clone --depth=1 https://github.com/catppuccin/kde catppuccin-kde && cd catppuccin-kde`
 2. Run the install script using `./install.sh` and follow the instructions.
 
+#### Automated Installation
+You can install the KDE theme without interactions by calling the script with the following arguments:
+
+`./install.sh flavour accent window_decoration_mode auto`
+
+Example:
+`./install.sh Mocha Blue Classic auto`
+
 ### For Krita:
 1. Download the colour-scheme zip file for your preffered flavour from the [release](https://github.com/catppuccin/kde/releases/) tab.
 2. Extract the file and move the theme(s) you wish to install into the following folders for your platform:

--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,9 @@ ACCENT="$2"
 WINDECSTYLE="$3"
 DEBUGMODE="$4"
 
-clear
+if [ "$DEBUGMODE" != "-y" ]; then
+    clear
+fi
 
 if [ -z "$1" ]; then
     cat <<EOF
@@ -45,7 +47,9 @@ Choose flavor out of -
     (Type the number corresponding to said palette)
 EOF
     read -r FLAVOUR
-    clear
+    if [ "$DEBUGMODE" != "-y" ]; then
+        clear
+    fi
 fi
 
 case "$FLAVOUR" in
@@ -80,7 +84,9 @@ Choose an accent -
     14. Lavender
 EOF
     read -r ACCENT
-    clear
+    if [ "$DEBUGMODE" != "-y" ]; then
+        clear
+    fi
 fi
 
 # Sets accent based on the palette selected (Best to fold this in your respective editor)
@@ -229,7 +235,9 @@ Choose window decoration style -
     2. Classic (MacOS like)
 EOF
     read -r WINDECSTYLE
-    clear
+    if [ "$DEBUGMODE" != "-y" ]; then
+        clear
+    fi
 fi
 
 WINDECSTYLENAME=""
@@ -399,11 +407,15 @@ case "$DEBUGMODE" in
         echo
         echo "Install $FLAVOURNAME $ACCENTNAME? with the $WINDECSTYLENAME window Decorations? [y/N]:"
         read -r CONFIRMATION
-        clear
+        if [ "$DEBUGMODE" != "-y" ]; then
+            clear
+        fi
         ;;
-	auto)
+	-y)
 		CONFIRMATION=Y
-		clear
+		if [ "$DEBUGMODE" != "-y" ]; then
+            clear
+        fi
 		;;
 	aurorae)
 		InstallAuroraeTheme
@@ -447,7 +459,7 @@ if [ "$CONFIRMATION" = "Y" ] || [ "$CONFIRMATION" = "y" ]; then
     echo "Cleaning up.."
 	rm -r ./dist
 
-    if [ "$DEBUGMODE" != "auto" ]; then
+    if [ "$DEBUGMODE" != "-y" ]; then
         # Apply theme
         echo
         echo "Do you want to apply theme? [y/N]:"
@@ -456,7 +468,9 @@ if [ "$CONFIRMATION" = "Y" ] || [ "$CONFIRMATION" = "y" ]; then
 
     if [ "$CONFIRMATION" = "Y" ] || [ "$CONFIRMATION" = "y" ]; then
         lookandfeeltool -a "$GLOBALTHEMENAME"
-        clear
+        if [ "$DEBUGMODE" != "-y" ]; then
+            clear
+        fi
         # Some legacy apps still look in ~/.icons
         cat <<EOF
 The cursors will fully apply once you log out

--- a/install.sh
+++ b/install.sh
@@ -401,10 +401,10 @@ case "$DEBUGMODE" in
         read -r CONFIRMATION
         clear
         ;;
-    auto)
-        CONFIRMATION=Y
-        clear
-        ;;
+	auto)
+		CONFIRMATION=Y
+		clear
+		;;
 	aurorae)
 		InstallAuroraeTheme
 		exit

--- a/install.sh
+++ b/install.sh
@@ -401,6 +401,10 @@ case "$DEBUGMODE" in
         read -r CONFIRMATION
         clear
         ;;
+    auto)
+        CONFIRMATION=Y
+        clear
+        ;;
 	aurorae)
 		InstallAuroraeTheme
 		exit
@@ -443,10 +447,12 @@ if [ "$CONFIRMATION" = "Y" ] || [ "$CONFIRMATION" = "y" ]; then
     echo "Cleaning up.."
 	rm -r ./dist
 
-    # Apply theme
-    echo
-    echo "Do you want to apply theme? [y/N]:"
-    read -r CONFIRMATION
+    if [ "$DEBUGMODE" != "auto" ]; then
+        # Apply theme
+        echo
+        echo "Do you want to apply theme? [y/N]:"
+        read -r CONFIRMATION
+    fi
 
     if [ "$CONFIRMATION" = "Y" ] || [ "$CONFIRMATION" = "y" ]; then
         lookandfeeltool -a "$GLOBALTHEMENAME"


### PR DESCRIPTION
This new DEBUGMODE "auto" allows for a completely automated install of Catppuccin KDE themes. I developed this for usage in my dotfiles and others might benefit from similar use cases as well.