### PR TITLE
Specify version for QtQuick

### DIFF
--- a/Resources/splash-screen/contents/splash/Splash.qml
+++ b/Resources/splash-screen/contents/splash/Splash.qml
@@ -7,7 +7,7 @@
     SPDX-License-Identifier: MIT
 */
 
-import QtQuick
+import QtQuick 2.15
 import org.kde.kirigami 2 as Kirigami
 
 Rectangle {


### PR DESCRIPTION
## Issue 
Fixes https://github.com/catppuccin/kde/issues/80 where ksplashqml crashes on loading catpuccin splash screens.

## Changes
Specify version 2.15 of `QtQuick` to align with default splash screens provided with KDE. 