### PR TITLE
fix: rename 'sizes' to 'size' in Splash.qml

### DIFF
--- a/Resources/splash-screen/contents/splash/Splash.qml
+++ b/Resources/splash-screen/contents/splash/Splash.qml
@@ -53,7 +53,7 @@ Rectangle {
             source: "images/Logo.png"
 
             sourceSize.width: size
-            sourceSize.height: sizes
+            sourceSize.height: size
             smooth: true
             visible: true
         }


### PR DESCRIPTION
This PR resolves #87

- Replaces the undefined `sizes` property with `size` in `Splash.qml`.
- Fixes the `ReferenceError` caused by the non-existent property.