### PR TITLE
Modify theme application confirmation logic.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -448,7 +448,7 @@ if [ "$CONFIRMATION" = "Y" ] || [ "$CONFIRMATION" = "y" ]; then
     echo "Do you want to apply theme? [y/N]:"
     read -r CONFIRMATION
 
-    if [ "$CONFIRMATION" = "Y" ] || [ "$CONFIRMATION" = "y" ]; then
+    if [ "$CONFIRMATION" = "Y" ] || [ "$CONFIRMATION" = "y" ] || [ "$CONFIRMATION" = "" ]; then
         lookandfeeltool -a "$GLOBALTHEMENAME"
         clear
         # Some legacy apps still look in ~/.icons


### PR DESCRIPTION
Allow applying theme with empty confirmation input. I've seen a lot of people (me included) that just press Enter when a confirmation prompt appears.

Just a small tweak.