### PR TITLE
fix(decorations): restore BorderSize=None so windows use thin borders

### DIFF
--- a/Resources/LookAndFeel/defaults
+++ b/Resources/LookAndFeel/defaults
@@ -9,6 +9,8 @@ ButtonsOnLeft=
 ButtonsOnRight=IAX
 library=org.kde.kwin.aurorae
 theme=--aurorae
+BorderSize=None
+BorderSizeAuto=false
 
 [plasmarc][Theme]
 name=default


### PR DESCRIPTION
restores `BorderSize=None` to the look-and-feel `defaults` so windows use the theme's thin borders instead of KWin's thick default. it got dropped in 8fc32a7 when the kdecoration2 block was reordered. also sets `BorderSizeAuto=false` so plasma 6 actually honors it rather than auto-sizing.

Closes #89
