### PR TITLE
fix(colors): make selection-bar text readable on every accent

### DIFF
--- a/Resources/Base.colors
+++ b/Resources/Base.colors
@@ -68,14 +68,14 @@ BackgroundAlternate=--accentColor
 BackgroundNormal=--accentColor
 DecorationFocus=--accentColor
 DecorationHover=--accentColor
-ForegroundInactive=$mantle
-ForegroundActive=$peach
-ForegroundLink=--accentColor
-ForegroundNegative=$red
-ForegroundNeutral=$yellow
-ForegroundNormal=$crust
-ForegroundPositive=$green
-ForegroundVisited=$mauve
+ForegroundInactive=--selFg
+ForegroundActive=--selFg
+ForegroundLink=--selFg
+ForegroundNegative=--selFg
+ForegroundNeutral=--selFg
+ForegroundNormal=--selFg
+ForegroundPositive=--selFg
+ForegroundVisited=--selFg
 
 
 [Colors:Tooltip]

--- a/install.sh
+++ b/install.sh
@@ -290,7 +290,15 @@ esac
 
 BuildColorscheme() {
     # Add Metadata & Replace Accent in colors file
-    sed "s/--accentColor/$ACCENTCOLOR/g; s/--flavour/$FLAVOURNAME/g; s/--accentName/$ACCENTNAME/g" ./Resources/Base.colors > ./dist/base.colors
+    # Selection text is dark (crust) on the accent. Latte's darkest accents
+    # (red/mauve/blue) need white instead, crust is too low-contrast there.
+    SELFG="17, 17, 27"
+    if [ "$FLAVOURNAME" = "Latte" ]; then
+        case "$ACCENTNAME" in
+        Red | Mauve | Blue) SELFG="255, 255, 255" ;;
+        esac
+    fi
+    sed "s/--accentColor/$ACCENTCOLOR/g; s/--selFg/$SELFG/g; s/--flavour/$FLAVOURNAME/g; s/--accentName/$ACCENTNAME/g" ./Resources/Base.colors > ./dist/base.colors
     # Hydrate Dummy colors according to Pallet
     ./Installer/color-build.sh -f "$FLAVOURNAME" -o ./dist/Catppuccin"$FLAVOURNAME$ACCENTNAME".colors -s ./dist/base.colors
 }


### PR DESCRIPTION
the `[Colors:Selection]` link was the same color as the selection bar so it rendered invisible, and visited/status colors were low-contrast, across all 56 flavour×accent combos. now all selection foregrounds use one readable token: crust on the accents, white on Latte's red/mauve/blue where crust is too low-contrast. worst-case contrast goes from ~1.0 to 4.77 (WCAG AA).

Closes #115

Reference images I made in html btw, incase anyone wants to see before and after. Not all colors were bad contrast but a very large majority were: 

<img width="1138" height="1162" alt="Screenshot_20260620_025103" src="https://github.com/user-attachments/assets/c82dbcb7-ffdc-4452-9329-87e3118706fc" />
<img width="1138" height="1162" alt="Screenshot_20260620_025113" src="https://github.com/user-attachments/assets/e18137ce-70cc-4521-9528-883198792a12" />
<img width="1138" height="1162" alt="Screenshot_20260620_025122" src="https://github.com/user-attachments/assets/ad6361e5-2e40-4bc0-977d-22f7c03b4d5d" />
<img width="1132" height="1251" alt="Screenshot_20260620_025131" src="https://github.com/user-attachments/assets/8a61e6ff-e4e5-48ec-9f2d-a8f478033467" />
