### PR TITLE
fix(colors): keep selection text readable when its view is unfocused

### DIFF
--- a/Resources/Base.colors
+++ b/Resources/Base.colors
@@ -8,7 +8,7 @@ IntensityAmount=-1
 IntensityEffect=0
 
 [ColorEffects:Inactive]
-ChangeSelectionColor=true
+ChangeSelectionColor=false
 Color=$base
 ColorAmount=0.5
 ColorEffect=3


### PR DESCRIPTION
closes #74. when a panel/view is unfocused, kde renders its selected items with the Inactive palette group, and our [ColorEffects:Inactive] had ChangeSelectionColor=true, which recolored the selection until the text went light and hard to read (most visible in dolphin's places sidebar after navigating). flipping it to false keeps selected text readable whether or not the view has focus.
