### PR TITLE
ci: add repo automation (labeler, pr-title lint, release, templates)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Sourcastic @soleynn

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,122 @@
+name: Bug Report
+description: Report a bug or issue with the theme or installer
+title: "fix: <summary>"
+labels: ["type: bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: What steps did you take to trigger the issue?
+      placeholder: |
+        1. Run `./install.sh ...`
+        2. Open KDE Settings
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: false
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: true
+  - type: dropdown
+    id: plasma_version
+    attributes:
+      label: Plasma Version
+      description: Select the major Plasma version you are running.
+      options:
+        - Plasma 6.1
+        - Plasma 6.0
+        - Plasma 5.27 (LTS)
+        - Other (please specify in description)
+    validations:
+      required: true
+  - type: dropdown
+    id: distro
+    attributes:
+      label: Linux Distribution
+      description: Select the Linux distribution you are using.
+      options:
+        - Arch Linux
+        - Fedora
+        - openSUSE (Tumbleweed/Leap)
+        - KDE neon
+        - Debian
+        - Ubuntu / Kubuntu
+        - Manjaro
+        - Gentoo
+        - Void Linux
+        - NixOS
+        - Other (please specify in description)
+    validations:
+      required: true
+  - type: dropdown
+    id: flavour
+    attributes:
+      label: Theme Flavour
+      description: Select the flavour you selected in install.sh.
+      options:
+        - Mocha
+        - Macchiato
+        - Frappe
+        - Latte
+        - Multiple / All
+    validations:
+      required: true
+  - type: dropdown
+    id: accent
+    attributes:
+      label: Theme Accent
+      description: Select the accent color you selected in install.sh.
+      options:
+        - Rosewater
+        - Flamingo
+        - Pink
+        - Mauve
+        - Red
+        - Maroon
+        - Peach
+        - Yellow
+        - Green
+        - Teal
+        - Sky
+        - Sapphire
+        - Blue
+        - Lavender
+        - Multiple / All
+    validations:
+      required: true
+  - type: dropdown
+    id: decoration
+    attributes:
+      label: Window Decoration Style
+      description: Select the window decoration style.
+      options:
+        - Modern (Mixed)
+        - Classic (MacOS like)
+        - None / Other
+    validations:
+      required: true
+  - type: textarea
+    id: system_details
+    attributes:
+      label: System Info / Logs / Screenshots
+      description: Please share any logs (e.g. installer script output, kwin logs) or drag & drop screenshots demonstrating the issue.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Upstream KDE Bug Tracker
+    url: https://bugs.kde.org/
+    about: For bugs in KDE/Plasma itself, please use the upstream KDE bug tracker.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Feature Request
+description: Suggest an idea or feature for this theme
+title: "feat: <summary>"
+labels: ["type: enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem?
+      description: A clear and concise description of what the problem is. E.g. I'm always frustrated when [...]
+    validations:
+      required: false
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.
+    validations:
+      required: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions-weekly:
+        patterns:
+          - "*"
+    labels:
+      - "area: ci"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,30 @@
+"area: installer":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'install.sh'
+          - 'Installer/**/*'
+
+"area: assets":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Assets/**/*'
+
+"area: resources":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Resources/**/*'
+
+"area: ci":
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**/*'
+
+"area: tests":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'tests/**/*'
+
+"area: patches":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Patches/**/*'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- Briefly summarize the changes introduced by this pull request. -->
+
+## Changes
+
+- 
+
+---
+
+### PR Checklist
+- [ ] The PR title follows Conventional Commits (e.g. `feat(installer): ...`, `fix(resources): ...`).
+- [ ] A line has been added to the `[Unreleased]` section of CHANGELOG.md.

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,23 @@
+name: labeler
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: label
+    runs-on: ubuntu-latest
+    steps:
+      - name: label
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,42 @@
+name: "Lint PR Title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  statuses: write
+
+jobs:
+  main:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          scopes: |
+            assets
+            installer
+            resources
+            ci
+            tests
+            docs
+            patches
+          requireScope: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,10 +54,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           version="${GITHUB_REF_NAME#v}"
-          
+
           # Extract changelog section
           awk '/^## \['"$version"'\]/{flag=1; next} /^## \[/ || /^\[/{flag=0} flag' CHANGELOG.md > release_notes.md
-          
+
           # Deriving contributors function
           resolve_github_username() {
             local name="$1"
@@ -115,7 +115,7 @@ jobs:
 
           if prev_tag=$(git describe --tags --abbrev=0 "${GITHUB_REF_NAME}^" 2>/dev/null); then
             echo "Previous tag found: $prev_tag"
-            
+
             # Primary authors
             for sha in $(git log "${prev_tag}..${GITHUB_REF_NAME}" --format='%H'); do
               login=$(gh api "repos/${{ github.repository }}/commits/$sha" --jq '.author.login' 2>/dev/null || true)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,181 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Verify version consistency
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          echo "Verifying consistency for version: $version"
+
+          # 1. Check CHANGELOG.md
+          if ! grep -q "^## \[$version\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md does not contain heading '## [$version]'"
+            exit 1
+          fi
+
+          # 2. Check metadata.json files (10 files)
+          while IFS= read -r f; do
+            file_ver=$(jq -r '.KPlugin.Version' "$f")
+            if [ "$file_ver" != "$version" ]; then
+              echo "::error::$f version ($file_ver) does not match tag version ($version)"
+              exit 1
+            fi
+          done < <(find Resources -name "metadata.json")
+
+          # 3. Check metadata.desktop files (10 files)
+          while IFS= read -r f; do
+            file_ver=$(grep "^X-KDE-PluginInfo-Version=" "$f" | cut -d'=' -f2)
+            if [ "$file_ver" != "$version" ]; then
+              echo "::error::$f version ($file_ver) does not match tag version ($version)"
+              exit 1
+            fi
+          done < <(find Resources -name "metadata.desktop")
+
+          echo "All version checks passed!"
+
+      - name: Extract Release Notes and Contributors
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          
+          # Extract changelog section
+          awk '/^## \['"$version"'\]/{flag=1; next} /^## \[/ || /^\[/{flag=0} flag' CHANGELOG.md > release_notes.md
+          
+          # Deriving contributors function
+          resolve_github_username() {
+            local name="$1"
+            local email="$2"
+            local username=""
+
+            # Check if noreply
+            if echo "$email" | grep -q "@users\.noreply\.github\.com"; then
+              username=$(echo "$email" | sed -E 's/[0-9]+\+([^@]+)@users\.noreply\.github\.com/\1/')
+              if [ -n "$username" ]; then
+                echo "@$username"
+                return 0
+              fi
+            fi
+
+            # Check email search
+            if [ -n "$email" ]; then
+              username=$(gh api "search/users?q=${email}" --jq '.items[0].login' 2>/dev/null || true)
+              if [ -n "$username" ] && [ "$username" != "null" ]; then
+                echo "@$username"
+                return 0
+              fi
+            fi
+
+            # Check name search
+            if [ -n "$name" ]; then
+              local query_name
+              query_name=$(echo "$name" | tr ' ' '+')
+              username=$(gh api "search/users?q=${query_name}" --jq '.items[0].login' 2>/dev/null || true)
+              if [ -n "$username" ] && [ "$username" != "null" ]; then
+                echo "@$username"
+                return 0
+              fi
+            fi
+
+            # Fallback to name
+            if [[ "$name" =~ [[:space:]] ]]; then
+              echo "$name"
+            else
+              echo "@$name"
+            fi
+          }
+
+          contributors=""
+          add_contributor() {
+            local contrib="$1"
+            if [ -n "$contrib" ]; then
+              if [ -z "$contributors" ]; then
+                contributors="$contrib"
+              else
+                contributors="$contributors"$'\n'"$contrib"
+              fi
+            fi
+          }
+
+          if prev_tag=$(git describe --tags --abbrev=0 "${GITHUB_REF_NAME}^" 2>/dev/null); then
+            echo "Previous tag found: $prev_tag"
+            
+            # Primary authors
+            for sha in $(git log "${prev_tag}..${GITHUB_REF_NAME}" --format='%H'); do
+              login=$(gh api "repos/${{ github.repository }}/commits/$sha" --jq '.author.login' 2>/dev/null || true)
+              if [ -n "$login" ] && [ "$login" != "null" ]; then
+                add_contributor "@$login"
+              else
+                author_info=$(git log -n 1 --format='%aN <%aE>' "$sha")
+                name=$(echo "$author_info" | sed -E 's/ <.*>//')
+                email=$(echo "$author_info" | sed -E 's/.*<(.*)>/\1/')
+                resolved=$(resolve_github_username "$name" "$email")
+                add_contributor "$resolved"
+              fi
+            done
+
+            # Co-authors
+            co_authors=$(git log "${prev_tag}..${GITHUB_REF_NAME}" | grep -i 'Co-authored-by:' | sed -E 's/.*Co-authored-by:[[:space:]]*//I' || true)
+            if [ -n "$co_authors" ]; then
+              while IFS= read -r line; do
+                [ -z "$line" ] && continue
+                name=$(echo "$line" | sed -E 's/ <.*>//')
+                email=$(echo "$line" | sed -E 's/.*<(.*)>/\1/')
+                resolved=$(resolve_github_username "$name" "$email")
+                add_contributor "$resolved"
+              done <<< "$co_authors"
+            fi
+          fi
+
+          if [ -n "$contributors" ]; then
+            # Filter bots & uniq
+            mapfile -t contrib_lines <<< "$(echo "$contributors" | grep -v "^$" | sort -f -u)"
+            clean_contribs=()
+            for c in "${contrib_lines[@]}"; do
+              [ -z "$c" ] && continue
+              if [[ "$c" =~ (github-actions|dependabot|renovate|copilot|snyk|codecov|lgtm|sonar) ]]; then
+                continue
+              fi
+              clean_contribs+=("$c")
+            done
+
+            count=${#clean_contribs[@]}
+            contrib_list=""
+            if [ "$count" -eq 1 ]; then
+              contrib_list="Thanks to ${clean_contribs[0]} for their contributions!"
+            elif [ "$count" -eq 2 ]; then
+              contrib_list="Thanks to ${clean_contribs[0]} and ${clean_contribs[1]} for their contributions!"
+            elif [ "$count" -gt 2 ]; then
+              contrib_list="Thanks to "
+              for ((i=0; i<count-1; i++)); do
+                contrib_list="${contrib_list}${clean_contribs[i]}, "
+              done
+              contrib_list="${contrib_list}and ${clean_contribs[count-1]} for their contributions!"
+            fi
+
+            if [ -n "$contrib_list" ]; then
+              echo -e "\n## Contributors\n\n$contrib_list" >> release_notes.md
+            fi
+          fi
+
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" --notes-file release_notes.md

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,6 @@
+Autumn McKee <autumn@mck.is> <git@mck.is>
+Cequallium <85212821+Cequallium@users.noreply.github.com> Cequal <85212821+Cequallium@users.noreply.github.com>
+Cequallium <85212821+Cequallium@users.noreply.github.com> <adityaojha@outlook.in>
+D3SOX <nico@d3sox.me> Nico <nico@d3sox.me>
+Pocco81 <58336662+Pocco81@users.noreply.github.com> <pocco451@gmail.com>
+Sourcastic <79325941+Sourcastic@users.noreply.github.com> M. Ibrahim <79325941+Sourcastic@users.noreply.github.com>

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 </h3>
 
 <p align="center">
+    <a href="https://github.com/catppuccin/kde/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/catppuccin/kde/ci.yml?branch=main&colorA=363a4f&label=CI&style=for-the-badge"></a>
     <a href="https://github.com/catppuccin/kde/stargazers"><img src="https://img.shields.io/github/stars/catppuccin/kde?colorA=363a4f&colorB=b7bdf8&style=for-the-badge"></a>
     <a href="https://github.com/catppuccin/kde/issues"><img src="https://img.shields.io/github/issues/catppuccin/kde?colorA=363a4f&colorB=f5a97f&style=for-the-badge"></a>
     <a href="https://github.com/catppuccin/kde/contributors"><img src="https://img.shields.io/github/contributors/catppuccin/kde?colorA=363a4f&colorB=a6da95&style=for-the-badge"></a>


### PR DESCRIPTION
stacked on #129 (base ci/validators).

repo automation + community-health files.

- pr-title lint (conventional types + scopes); runs on pull_request_target so
  fork PRs get a status
- labeler: path-based `area:` labels (sha-pinned actions/labeler v5); the new
  area labels are pre-created on the repo
- dependabot: github-actions, weekly, grouped
- tag-triggered release workflow: checks the tag against the changelog heading
  and all 20 version-bearing files, pulls notes from the changelog section,
  derives contributors (bots filtered)
- issue forms (bug/feature, blank issues off, upstream kde tracker link), pr
  template, codeowners
