### PR TITLE
ci: accept capitalized pr-title types and the deps scope

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -19,18 +19,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          # types are regex (auto-wrapped in ^ $); the case-class first letter
+          # accepts a capitalized type like dependabot's "Chore(deps)"
           types: |
-            feat
-            fix
-            docs
-            style
-            refactor
-            perf
-            test
-            build
-            ci
-            chore
-            revert
+            [Ff]eat
+            [Ff]ix
+            [Dd]ocs
+            [Ss]tyle
+            [Rr]efactor
+            [Pp]erf
+            [Tt]est
+            [Bb]uild
+            [Cc]i
+            [Cc]hore
+            [Rr]evert
           scopes: |
             assets
             installer
@@ -39,4 +41,5 @@ jobs:
             tests
             docs
             patches
+            deps
           requireScope: false


### PR DESCRIPTION
the pr-title lint matched types case-sensitively, so dependabot's default `Chore(deps): ...` title got rejected (#131).

- types now accept a capitalized first letter (they're regex, so a `[Cc]hore`-style class), so `Chore` and `chore` both pass
- add `deps` to the allowed scopes for dependabot's `(deps)` scope